### PR TITLE
ci: split label and block-fixup into separate workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,14 @@
+docs:
+  - changed-files:
+      - any-glob-to-any-file: "docs/**"
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/**"
+          - "docker-compose.yml"
+          - "Dockerfile"
+
+test:
+  - changed-files:
+      - any-glob-to-any-file: "tests/**"

--- a/.github/workflows/block-fixup.yml
+++ b/.github/workflows/block-fixup.yml
@@ -1,0 +1,106 @@
+# This GitHub Actions workflow checks for any 'fixup!' or 'squash!' commits in the push.
+# It ensures that no such commits are present, prompting developers to clean up their commit history
+# before merging their changes. This helps maintain a clean and meaningful commit history.
+
+name: Block 'fixup!' and 'squash!'
+
+on:
+  pull_request:
+
+permissions: write-all
+
+jobs:
+  block-fixup-and-squash:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Fetch the base branch and the PR branch
+        run: |
+          # Ensure that both the base and head branches are fetched
+          git fetch origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
+          git fetch origin +refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
+
+      - name: Block fixup and squash commits
+        id: check
+        run: |
+          # List commits between the base branch and the PR branch
+          commits=$(git log --pretty=format:"%h %s" origin/${{ github.base_ref }}..origin/${{ github.head_ref }})
+          if [ $? -ne 0 ]; then
+            echo "error::Git command failed"
+            exit 1
+          fi
+
+          echo "Checking commits"
+          while IFS= read -r commit; do
+            hash=$(echo $commit | cut -d ' ' -f 1)
+            message=$(echo $commit | cut -d ' ' -f 2-)
+
+            if [[ $message == fixup!* ]] || [[ $message == squash!* ]]; then
+              echo "error::Commit $hash starts with 'fixup!' or 'squash!': $message"
+              offending_commits="$offending_commits\n$hash: $message"
+            else
+              echo "$hash: $message"
+            fi
+
+          done <<< "$commits"
+
+          if [ -n "$offending_commits" ]; then
+            echo "commits<<EOF" >> $GITHUB_OUTPUT
+            echo -e "$offending_commits" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            exit 1
+          else
+            echo "commits=" >> $GITHUB_OUTPUT
+            echo "All commits passed the checks!"
+          fi
+
+      - name: Manage sticky comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const header = '<!-- fixup-squash -->';
+            const commits = `${{ steps.check.outputs.commits }}`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(header));
+
+            if (commits) {
+              const body = [
+                header,
+                'Your Pull Request contains a commit that starts with `fixup!` or `squash!`.',
+                'Offending commit:',
+                '```',
+                commits,
+                '```',
+                'Please remove these commits before merging.',
+              ].join('\n');
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } else if (existing) {
+              await github.rest.issues.deleteComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+              });
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,53 +9,6 @@ env:
   PYTHON_VERSION: "3.14"
 
 jobs:
-  label:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            const title = context.payload.pull_request.title;
-            const map = {
-              feature: /^feat/,
-              fix: /^fix/,
-              refactor: /^refactor/,
-              chore: /^chore/,
-              docs: /^docs/,
-              ci: /^ci/,
-              test: /^test/,
-            };
-            const labels = Object.entries(map)
-              .filter(([, re]) => re.test(title))
-              .map(([k]) => k);
-            if (labels.length > 0) {
-              await github.rest.issues.addLabels({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                labels,
-              });
-            }
-
-  block-fixup:
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Block fixup! and squash! commits
-        run: |
-          COMMITS=$(git log --format='%s' origin/${{ github.base_ref }}..HEAD)
-          if echo "$COMMITS" | grep -qE '^(fixup!|squash!) '; then
-            echo "::error::Found fixup! or squash! commits. Please rebase before merging."
-            echo "$COMMITS" | grep -E '^(fixup!|squash!) '
-            exit 1
-          fi
-
   ruff:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,94 @@
+# This workflow will add labels to the Pull Request based on the changes
+#
+# For more information, see:
+# https://github.com/actions/labeler
+
+name: Add PR Label
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          sync-labels: false
+
+  label_by_commit_message:
+    runs-on: ubuntu-latest
+    permissions: write-all
+
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+
+    outputs:
+      commit_message: ${{ steps.get_commit.outputs.commit_message }}
+      label: ${{ steps.determine_label.outputs.label }}
+      label_color: ${{ steps.determine_label.outputs.label_color }}
+      label_description: ${{ steps.determine_label.outputs.label_description }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Get commit message
+        id: get_commit
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=format:"%s" ${{ github.event.pull_request.head.sha }} | sed 's/"/\\"/g' )
+          echo "$COMMIT_MSG"
+          echo "commit_message=$COMMIT_MSG" >> $GITHUB_OUTPUT
+
+      - name: Determine label
+        id: determine_label
+        run: |
+          declare -A LABELS
+          LABELS[chore]="bfd4f2 Maintenance"
+          LABELS[feature]="1a7f37 New feature"
+          LABELS[fix]="d73a4a Bug fix"
+          LABELS[refactor]="1d76db Code refactoring"
+          LABELS[revert]="141c19 Revert codes"
+          LABELS[test]="0e8a16 Tests"
+          LABELS[docs]="a259ff Documentation"
+          LABELS[ci]="e3b341 CI/CD changes"
+
+          COMMIT_TYPE=$(echo "${{ steps.get_commit.outputs.commit_message }}" | grep -oE '^(chore|feat|fix|refactor|revert|test|docs|ci)(\(|:)+' | sed 's/[()|:]//g' )
+          if [[ "$COMMIT_TYPE" == "feat" ]]; then
+            COMMIT_TYPE="feature"
+          fi
+          echo "COMMIT_TYPE: $COMMIT_TYPE"
+
+          if [[ -n "$COMMIT_TYPE" ]]; then
+            LABEL_COLOR_DESCRIPTION=${LABELS[$COMMIT_TYPE]}
+            COLOR=$(echo "$LABEL_COLOR_DESCRIPTION" | awk '{print $1}')
+            DESCRIPTION=$(echo "$LABEL_COLOR_DESCRIPTION" | cut -d' ' -f2-)
+            echo "label=$COMMIT_TYPE" >> $GITHUB_OUTPUT
+            echo "label_color=$COLOR" >> $GITHUB_OUTPUT
+            echo "label_description=$DESCRIPTION" >> $GITHUB_OUTPUT
+          else
+            echo "::warning:: No commit type found! Not possible to set a label"
+          fi
+
+      - name: Show error if PR doesn't exist
+        if: ${{ env.PR_NUMBER == '' }}
+        run: |
+          echo "::error:: No associated Pull Request found!"
+          exit 1
+
+      - name: Add label to PR
+        if: ${{ steps.determine_label.outputs.label != '' }}
+        run: |
+          gh label create "${{ steps.determine_label.outputs.label }}" --description "${{ steps.determine_label.outputs.label_description }}" --color  "${{ steps.determine_label.outputs.label_color }}" --force
+          gh pr edit ${{ env.PR_NUMBER }} --add-label "${{ steps.determine_label.outputs.label }}"
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- `label` と `block-fixup` ジョブを `ci.yml` から分離し、専用ワークフローに移行
- `labeler.yml`: ファイルパスベース (`actions/labeler`) + コミットメッセージベースのラベル自動付与（色・説明付き）
- `block-fixup.yml`: `fixup!`/`squash!` コミットの検出 + PR sticky comment（`actions/github-script` で自前実装、外部アクション不使用）
- `.github/labeler.yml`: `actions/labeler` 用のファイルパスルール定義

## Test plan
- [ ] PR作成時にコミットメッセージに応じたラベルが付与されること
- [ ] `fixup!` コミットを含むPRでコメントが投稿されること
- [ ] CI（ruff, mypy, ty, tests, commitlint）が引き続き正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)