### PR TITLE
ci: fix workflows and add missing commitlint types

### DIFF
--- a/.github/workflows/block-fixup.yml
+++ b/.github/workflows/block-fixup.yml
@@ -7,96 +7,62 @@ name: Block 'fixup!' and 'squash!'
 on:
   pull_request:
 
-permissions: write-all
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
   block-fixup-and-squash:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Fetch the base branch and the PR branch
-        run: |
-          # Ensure that both the base and head branches are fetched
-          git fetch origin +refs/heads/${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
-          git fetch origin +refs/heads/${{ github.head_ref }}:refs/remotes/origin/${{ github.head_ref }}
-
-      - name: Block fixup and squash commits
-        id: check
-        run: |
-          # List commits between the base branch and the PR branch
-          commits=$(git log --pretty=format:"%h %s" origin/${{ github.base_ref }}..origin/${{ github.head_ref }})
-          if [ $? -ne 0 ]; then
-            echo "error::Git command failed"
-            exit 1
-          fi
-
-          echo "Checking commits"
-          while IFS= read -r commit; do
-            hash=$(echo $commit | cut -d ' ' -f 1)
-            message=$(echo $commit | cut -d ' ' -f 2-)
-
-            if [[ $message == fixup!* ]] || [[ $message == squash!* ]]; then
-              echo "error::Commit $hash starts with 'fixup!' or 'squash!': $message"
-              offending_commits="$offending_commits\n$hash: $message"
-            else
-              echo "$hash: $message"
-            fi
-
-          done <<< "$commits"
-
-          if [ -n "$offending_commits" ]; then
-            echo "commits<<EOF" >> $GITHUB_OUTPUT
-            echo -e "$offending_commits" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
-            exit 1
-          else
-            echo "commits=" >> $GITHUB_OUTPUT
-            echo "All commits passed the checks!"
-          fi
-
-      - name: Manage sticky comment
-        if: always()
+      - name: Check commits and manage comment
         uses: actions/github-script@v7
         with:
           script: |
-            const header = '<!-- fixup-squash -->';
-            const commits = `${{ steps.check.outputs.commits }}`;
+            const HEADER = '<!-- fixup-squash -->';
+            const PATTERN = /^(fixup!|squash!) /;
+
+            // Get all commits in this PR
+            const { data: commits } = await github.rest.pulls.listCommits({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const offending = commits
+              .filter(c => PATTERN.test(c.commit.message))
+              .map(c => `${c.sha.slice(0, 7)}: ${c.commit.message.split('\n')[0]}`);
+
+            // Find existing sticky comment
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
             });
-            const existing = comments.find(c => c.body.includes(header));
+            const existing = comments.find(c => c.body.includes(HEADER));
 
-            if (commits) {
+            // Upsert or delete comment
+            if (offending.length > 0) {
               const body = [
-                header,
-                'Your Pull Request contains a commit that starts with `fixup!` or `squash!`.',
-                'Offending commit:',
+                HEADER,
+                'Your Pull Request contains commits that start with `fixup!` or `squash!`.',
+                'Offending commits:',
                 '```',
-                commits,
+                ...offending,
                 '```',
                 'Please remove these commits before merging.',
               ].join('\n');
 
-              if (existing) {
-                await github.rest.issues.updateComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  comment_id: existing.id,
-                  body,
-                });
-              } else {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: context.issue.number,
-                  body,
-                });
-              }
+              const params = existing
+                ? { owner: context.repo.owner, repo: context.repo.repo, comment_id: existing.id, body }
+                : { owner: context.repo.owner, repo: context.repo.repo, issue_number: context.issue.number, body };
+
+              await (existing
+                ? github.rest.issues.updateComment(params)
+                : github.rest.issues.createComment(params));
+
+              core.setFailed(`Found ${offending.length} fixup/squash commit(s)`);
             } else if (existing) {
               await github.rest.issues.deleteComment({
                 owner: context.repo.owner,

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -10,6 +10,9 @@ module.exports = {
         "refactor",
         "test",
         "chore",
+        "ci",
+        "docs",
+        "revert",
       ]
     ],
     "subject-case": [2, "never", ["sentence-case", "start-case", "pascal-case", "upper-case"]],


### PR DESCRIPTION
## Summary
- block-fixup を `actions/github-script` 1ステップに簡略化（checkout/bash 不要に）
- labeler の `actions/checkout@v6` → `v4` に修正
- commitlint の `type-enum` に `ci`, `docs`, `revert` を追加

## Test plan
- [ ] block-fixup ワークフローが正常に動作すること
- [ ] labeler ワークフローが正常に動作すること
- [ ] commitlint が `ci:` プレフィックスを許可すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)