### PR TITLE
ci: add linting_test, django_check, and migration_check jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,37 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - run: uv run pytest tests/integration --maxfail=1 --disable-warnings -q --no-cov
 
+  linting_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-env
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: uv run pytest tests/linting --numprocesses auto --no-cov
+
+  django_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-env
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: uv run python -m django check --fail-level WARNING
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings.dev
+
+  migration_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-python-env
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - run: uv run python -m django makemigrations --check --dry-run
+        env:
+          DJANGO_SETTINGS_MODULE: config.settings.dev
+
   coverage:
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
## Summary
- `linting_test`: カスタム fixit ルールのテスト (`tests/linting/`) を専用ジョブで実行
- `django_check`: Django system check (`manage.py check --fail-level WARNING`) でモデル/settings の整合性を検証
- `migration_check`: `makemigrations --check --dry-run` でマイグレーション漏れを検出

## Test plan
- [ ] 3ジョブが CI で正常に完了することを確認
- [ ] 既存ジョブに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)