### PR TITLE
ci: add trivy security scan for Dockerfile and docker-compose

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -8,6 +8,7 @@ ci:
           - ".github/**"
           - "docker-compose.yml"
           - "Dockerfile"
+          - "trivy.yaml"
 
 test:
   - changed-files:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -49,6 +49,7 @@ branches:
           - integration_test
           - commitlint
           - block-fixup-and-squash
+          - trivy
       enforce_admins: true
       required_linear_history: true
       allow_force_pushes: false

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,17 @@
+name: Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: "config"
+          scan-ref: "."
+          trivy-config: trivy.yaml

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -1,0 +1,8 @@
+scan:
+  scanners:
+    - misconfig
+
+misconfig:
+  include:
+    - dockerfile
+    - docker-compose


### PR DESCRIPTION
## Summary
- Trivy による IaC ミスコンフィグ検出ワークフロー (`Security Scan`) を新規追加
- Dockerfile と docker-compose.yml を対象にスキャン
- `trivy` を required status checks に追加し、マージ前にセキュリティチェックを必須化

## Test plan
- [ ] GitHub Actions 上で `trivy` ジョブが正常に実行されることを確認
- [ ] Dockerfile / docker-compose.yml にミスコンフィグがある場合に検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)